### PR TITLE
Added missing 3ds buttons + reordered list

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -48,7 +48,7 @@ class Header extends Component {
         style={{backgroundImage: `url(${platformIcons[this.platform]})`}}>
           <option value="switch">Switch&nbsp;&nbsp;</option>
           <option value="wiiu">Wii U&nbsp;&nbsp;</option>
-          <option value="all">Both&nbsp;&nbsp;</option>
+          <option value="all">All&nbsp;&nbsp;</option>
           <option value="3ds">3DS&nbsp;&nbsp;</option>
       </select>
     </Fragment>);

--- a/src/Header.js
+++ b/src/Header.js
@@ -46,10 +46,10 @@ class Header extends Component {
       <span className="platform"> for </span>
       <select id="device" defaultValue={this.platform} onChange={this.sub}
         style={{backgroundImage: `url(${platformIcons[this.platform]})`}}>
-          <option value="switch">Switch&nbsp;&nbsp;</option>
-          <option value="wiiu">Wii U&nbsp;&nbsp;</option>
           <option value="all">All&nbsp;&nbsp;</option>
           <option value="3ds">3DS&nbsp;&nbsp;</option>
+          <option value="switch">Switch&nbsp;&nbsp;</option>
+          <option value="wiiu">Wii U&nbsp;&nbsp;</option>
       </select>
     </Fragment>);
 

--- a/src/PlatformPicker.js
+++ b/src/PlatformPicker.js
@@ -4,7 +4,8 @@ import { platformIcons } from "./Utils";
 export const plats = {
     "wiiu": "Wii U",
     "switch": "Switch",
-    "all": "Both",
+    "3ds": "3DS",
+    "all": "All",
 };
 
 const PlatformPicker = ({path = ""}) => {

--- a/src/PlatformPicker.js
+++ b/src/PlatformPicker.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { platformIcons } from "./Utils";
 
 export const plats = {
-    "wiiu": "Wii U",
-    "switch": "Switch",
-    "3ds": "3DS",
     "all": "All",
+    "3ds": "3DS",
+    "switch": "Switch",
+    "wiiu": "Wii U",
 };
 
 const PlatformPicker = ({path = ""}) => {

--- a/src/Quickstore.css
+++ b/src/Quickstore.css
@@ -79,7 +79,7 @@
 
 .clearfix::after {
     content: "";
-    clear: both;
+    clear: all;
     display: table;
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,10 +7,10 @@
     "homebrewDescription": "Homebrew App Store is a free and open-source repository of <0>homebrew apps</0> for the Wii U and Switch consoles. The apps, tools, and games distributed here are all made by independent software developers within the community.",
     "submitRequest": "If you would like to list your own open-source app here, or request an existing one to add to this index, please see the <0>Submit</0> page. For other info about the team and project, see our <1>About</1> page.",
     "choosePlatform": "Choose a Platform",
-    "wiiu": "Wii U",
-    "switch": "Switch",
-    "3ds": "3DS",
     "all": "All",
+    "3ds": "3DS",
+    "switch": "Switch",
+    "wiiu": "Wii U",
 
   "- App Listing UI": "-",
     "allApps": "All Apps",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,7 +9,8 @@
     "choosePlatform": "Choose a Platform",
     "wiiu": "Wii U",
     "switch": "Switch",
-    "both": "Both",
+    "3ds": "3DS",
+    "all": "All",
 
   "- App Listing UI": "-",
     "allApps": "All Apps",


### PR DESCRIPTION
The 3DS button was missing in some places this PR would fix that. The console list is now reorganized to have "All" be at the beginning of the list then it goes down in alphabetical order. I've also changed the word "both" to "all" as more than 2 consoles are listed.