### PR TITLE
Fix description overflow on mobile

### DIFF
--- a/src/MainDisplay.css
+++ b/src/MainDisplay.css
@@ -762,8 +762,9 @@ details summary {
   }
 
   .AppDetails .details {
-    width: 100%;
-    margin-left: 0px;
+    width: 90vw;
+    margin: 0;
+    overflow-wrap: break-word;
   }
 
   .screen_container {


### PR DESCRIPTION
This fixes the horizontal overflow on mobile when some "words" are too long.